### PR TITLE
#12 Add support for custom MAIL FROM domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,42 @@ To wait until the domain identity is verified, add a [Custom::VerifiedIdentity](
       ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-ses-provider'
 ```
 
+If you wish to add a MAIL FROM domain, add a [Custom::MailFromDomain](docs/MailFromDomain.md):
+```yaml
+Resources:
+  MailFromDomain:
+    Type: Custom::MailFromDomain
+    Properties:
+      Domain: !Ref 'ExternalDomainName'
+      Region: !Ref 'EmailRegion'
+      MailFromSubdomain: 'mail'
+      ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-ses-provider'
+```
+
+You can verify the MAIL FROM domain in Route53 like this:
+```yaml
+  MailFromDomainVerificationRecords:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+        Comment: !Sub 'SES MAIL FROM domain for ${ExternalDomainName}'
+        HostedZoneId: !Ref 'HostedZone'
+        RecordSets: !GetAtt 'MailFromDomain.RecordSets'
+	RecordSetDefaults:
+	  TTL: 60
+	  Weight: 1
+	  SetIdentifier: !Ref 'AWS::Region'
+```
+
+To wait until the MAIL FROM domain is verified, add a [Custom::VerifiedMailFromDomain](docs/VerifiedMailFromDomain.md):
+```yaml
+  VerifiedMailFromDomain:
+    Type: Custom::VerifiedMailFromDomain
+    Properties:
+      Identity: !GetAtt 'DomainIdentity.Domain'
+      Region: !GetAtt 'DomainIdentity.Region'
+      ServiceToken: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-ses-provider'
+```
+
 If you wish to configure the notifications, add a [Custom::IdentityNotifications](docs/IdentityNotifications.md):
 ```yaml
   DomainNotifications:

--- a/docs/MailFromDomain.md
+++ b/docs/MailFromDomain.md
@@ -1,0 +1,50 @@
+# Custom::MailFromDomain
+The `Custom::MailFromDomain` sets a MAIL FROM value for the domain in SES.
+
+## Syntax
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+```yaml
+  Type : "Custom::MailFromDomain"
+  Properties:
+    Domain: String
+    Region: String
+    MailFromSubdomain: String
+    BehaviorOnMXFailure: String
+    RecordSetDefaults:
+      TTL: 60
+    ServiceToken : !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-ses-provider'
+```
+It will set the MAIL FROM value in SES for the `Domain` in `Region` to be `{MailFromSubdomain}.{Domain}`. It will also return 
+the DNS MX and TXT records to demonstrate ownership of the domain in DNS. 
+
+
+## Properties
+You can specify the following properties:
+
+    "Domain" - identity to create 
+    "Region" - to create the identity in
+    "MailFromSubdomain" - the subdomain to use as the MAIL FROM domain, will be prepended to domain
+    "BehaviorOnMXFailure" - action that Amazon SES takes if it cannot successfully read the required MX record when you send an email (UseDefaultValue | RejectMessage, defaults to UseDefaultValue)
+    "RecordSetDefaults" - for the resulting DNS records, defaults to {"TTL": 60}
+    "ServiceToken" - pointing to the domain identity provider
+
+## Return values
+'Ref' will return `Domain`@`Region`.
+
+With 'Fn::GetAtt' the following values are available:
+
+- `RecordSets` - Route53 recordset to validate the mail from domain
+- `Domain` - the name of the domain identity.
+- `Region` - the region of the domain identity.
+
+You can demonstrate ownership of the domain to AWS, as follows:
+
+```yaml
+  VerificationMailFromRecord:
+    Type: AWS::Route53::RecordSetGroup
+    Properties:
+        Comment: !Sub 'SES identity validation for ${ExternalDomainName}'
+        HostedZoneId: !Ref 'HostedZone'
+        RecordSets: !GetAtt 'MailFromDomain.RecordSets'
+```

--- a/docs/VerifiedMailFromDomain.md
+++ b/docs/VerifiedMailFromDomain.md
@@ -1,0 +1,30 @@
+# Custom::VerifiedMailFromDomain
+The `Custom::VerifiedMailFromDomain` waits until a SES MAIL FROM setting reaches the state 'Verified'.
+
+## Syntax
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+```yaml
+  Type : "Custom::VerifiedMailFromDomain"
+  Properties:
+    Identity: String
+    Region: String
+    ServiceToken : !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:binxio-cfn-ses-provider'
+```
+It will return the identity, once it reaches the state `Verified`
+
+## Properties
+You can specify the following properties:
+
+    "Identity" - to await verification
+    "Region" - the identity is created in
+    "ServiceToken" - pointing to the SES identity provider
+
+## Return values
+'Ref' will return `Identity`.
+
+With 'Fn::GetAtt' the following values are available:
+
+- `MailFromDomainStatus` - for the `Identity`
+- `Identity` - for the `Identity`
+- `Region` - of the `Identity`

--- a/src/mail_from_domain_provider.py
+++ b/src/mail_from_domain_provider.py
@@ -1,0 +1,103 @@
+from copy import deepcopy
+
+import boto3
+
+from ses_provider import SESProvider
+
+
+class MailFromDomainProvider(SESProvider):
+
+    def __init__(self):
+        super().__init__()
+        self.request_schema['required'].append("MailFromSubdomain")
+        self.request_schema['properties']['MailFromSubdomain'] = {"type": "string",
+                                                                  "description": "subdomain to use as mail from"}
+        self.request_schema['properties']['BehaviorOnMXFailure'] = {"type": "string",
+                                                                    "description": "action to take if "
+                                                                                   "Amazon SES cannot "
+                                                                                   "successfully read the "
+                                                                                   "required MX record "
+                                                                                   "when you send an "
+                                                                                   "email ("
+                                                                                   "UseDefaultValue | "
+                                                                                   "RejectMessage), "
+                                                                                   "default is "
+                                                                                   "UseDefaultValue"}
+
+    @property
+    def mail_from_subdomain(self):
+        return self.get("MailFromSubdomain")
+
+    @property
+    def behavior_on_mx_failure(self):
+        return self.get("BehaviorOnMXFailure")
+
+    def generate_dns_recordsets(self):
+        if self.mail_from_subdomain == "":
+            return []
+        else:
+            recordset_mx = deepcopy(self.get("RecordSetDefaults"))
+            recordset_mx.update(
+                {
+                    "Type": "MX",
+                    "Name": f"{self.mail_from_subdomain}.{self.domain}.",
+                    "ResourceRecords": [f'"10 feedback-smtp.{self.region}.amazonses.com"'],
+                }
+            )
+
+            recordset_txt = deepcopy(self.get("RecordSetDefaults"))
+            recordset_txt.update(
+                {
+                    "Type": "TXT",
+                    "Name": f"{self.mail_from_subdomain}.{self.domain}.",
+                    "ResourceRecords": ["v=spf1 include:amazonses.com ~all"],
+                }
+            )
+            return [recordset_mx, recordset_txt]
+
+    def set_mail_from(self):
+        try:
+            ses = boto3.client("ses", region_name=self.region)
+
+            mx_failure_behaviour = self.behavior_on_mx_failure
+
+            if mx_failure_behaviour is None:
+                mx_failure_behaviour = "UseDefaultValue"
+
+            ses.set_identity_mail_from_domain(Identity=self.domain, MailFromDomain=self.mail_from_subdomain,
+                                              BehaviorOnMXFailure=mx_failure_behaviour)
+
+            self.physical_resource_id = f"{self.domain}@{self.region}"
+
+            self.set_attribute("Domain", self.domain)
+            self.set_attribute("Region", self.region)
+            self.set_attribute("RecordSets", self.generate_dns_recordsets())
+        except Exception as e:
+            if not self.physical_resource_id:
+                self.physical_resource_id = "could-not-create"
+            self.fail(
+                f"could not set mail from domain for {self.mail_from_subdomain}.{self.domain}, {e}"
+            )
+
+    def create(self):
+        if self.identity_already_exists():
+            self.set_mail_from()
+        else:
+            self.physical_resource_id = "could-not-create"
+            self.fail(
+                f"SES domain identity {self.domain} must exist in region {self.region} before setting mail from value"
+            )
+
+    def update(self):
+        self.set_mail_from()
+
+    def delete(self):
+        self.properties['mail_from_subdomain'] = ""
+        self.set_mail_from()
+
+
+provider = MailFromDomainProvider()
+
+
+def handler(request, context):
+    return provider.handle(request, context)

--- a/src/ses.py
+++ b/src/ses.py
@@ -3,8 +3,10 @@ import logging
 import cfn_dkim_provider
 import dkim_tokens_provider
 import domain_identity_provider
+import mail_from_domain_provider
 import active_rule_set_provider
 import verified_identity_provider
+import verified_mail_from_domain_provider
 import identity_notifications_provider
 import identity_policy_provider
 
@@ -26,5 +28,9 @@ def handler(request, context):
         return verified_identity_provider.handler(request, context)
     elif request["ResourceType"] == "Custom::IdentityPolicy":
         return identity_policy_provider.handler(request, context)
+    elif request["ResourceType"] == "Custom::MailFromDomain":
+        return mail_from_domain_provider.handler(request, context)
+    elif request["ResourceType"] == "Custom::VerifiedMailFromDomain":
+        return verified_mail_from_domain_provider.handler(request, context)
     else:
         return cfn_dkim_provider.handler(request, context)

--- a/src/verified_mail_from_domain_provider.py
+++ b/src/verified_mail_from_domain_provider.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import time
+
+import boto3
+import json
+from cfn_resource_provider import ResourceProvider
+import logging
+
+
+lmbda = boto3.client("lambda")
+
+
+class VerifiedMailFromDomainProvider(ResourceProvider):
+    def __init__(self):
+        super(VerifiedMailFromDomainProvider, self).__init__()
+        self.request_schema = {
+            "type": "object",
+            "required": ["Identity", "Region"],
+            "properties": {
+                "Identity": {"type": "string", "description": "to await verification"},
+                "Region": {"type": "string", "description": "of to the identity"},
+            },
+        }
+        self._ses = None
+        self.interval_in_seconds = int(os.getenv("INTERVAL_IN_SECONDS", "15"))
+
+    @property
+    def identity(self):
+        return self.get("Identity").rstrip(".")
+
+    @property
+    def region(self):
+        return self.get("Region")
+
+    @property
+    def ses(self):
+        if not self._ses or self._ses.meta.region_name != self.region:
+            self._ses = boto3.client("ses", region_name=self.region)
+        return self._ses
+
+    def check(self):
+        self.physical_resource_id = self.identity
+        response = self.ses.get_identity_mail_from_domain_attributes(
+            Identities=[self.identity]
+        )
+        attrs = response["MailFromDomainAttributes"].get(self.identity, {})
+        mail_from_domain = attrs.get("MailFromDomain")
+        status = attrs.get("MailFromDomainStatus")
+        logging.info(
+            f'Verification of mail from domain "{mail_from_domain}" for {self.identity}" in region {self.region} is in state {status}.'
+        )
+        if status == "Success":
+            self.success(
+                f'mail from domain "{mail_from_domain}" for identity "{self.identity}" in region {self.region} is verified.'
+            )
+            self.set_attribute("Region", self.region)
+            self.set_attribute("Identity", self.identity)
+            self.set_attribute("MailFromDomainStatus", attrs.get("MailFromDomainStatus`"))
+        elif status == "Pending":
+            self.async_reinvoke()
+        else:
+            if status:
+                self.fail(
+                    f'Verification of mail from domain "{mail_from_domain}" for {self.identity}" in region {self.region} failed, state {status}. '
+                )
+            else:
+                self.fail(
+                    f'The identity "{self.identity}" does not exist in region {self.region}.'
+                )
+
+    def create(self):
+        self.check()
+
+    def update(self):
+        self.check()
+
+    def delete(self):
+        self.success("nothing to delete")
+
+    def invoke_lambda(self, payload):
+        lmbda.invoke(
+            FunctionName=self.get("ServiceToken"),
+            InvocationType="Event",
+            Payload=payload,
+        )
+
+    def async_reinvoke(self):
+        self.asynchronous = True  ## do not report result to CFN yet
+        time.sleep(self.interval_in_seconds)
+        self.increment_attempt()
+        payload = json.dumps(self.request).encode("utf-8")
+        self.invoke_lambda(payload)
+
+    @property
+    def attempt(self):
+        """ returns the number of attempts waiting for completion """
+        return int(self.get("Attempt", 1))
+
+    def increment_attempt(self):
+        """ returns the number of attempts waiting for completion """
+        self.properties["Attempt"] = self.attempt + 1
+
+
+provider = VerifiedMailFromDomainProvider()
+
+
+def handler(request, context):
+    return provider.handle(request, context)

--- a/tests/test_mail_from_domain_provider.py
+++ b/tests/test_mail_from_domain_provider.py
@@ -1,0 +1,79 @@
+import uuid
+
+from mail_from_domain_provider import MailFromDomainProvider
+
+
+def test_request_schema_has_correct_additional_properties():
+    mail_from_provider = MailFromDomainProvider()
+    assert('required' in mail_from_provider.request_schema)
+    assert('Domain' in mail_from_provider.request_schema['required'])
+    assert('Region' in mail_from_provider.request_schema['required'])
+    assert('MailFromSubdomain' in mail_from_provider.request_schema['required'])
+    assert('properties' in mail_from_provider.request_schema)
+    assert('MailFromSubdomain' in mail_from_provider.request_schema['properties'])
+    assert('BehaviorOnMXFailure' in mail_from_provider.request_schema['properties'])
+
+
+def test_generate_dns_recordsets_returns_empty_when_no_subdomain():
+    mail_from_provider = MailFromDomainProvider()
+    request = Request("Create", "example.com", "")
+    mail_from_provider.set_request(request, {})
+    assert(mail_from_provider.is_valid_request())
+    assert(mail_from_provider.domain == "example.com")
+    assert(mail_from_provider.mail_from_subdomain == "")
+    recordsets = mail_from_provider.generate_dns_recordsets()
+    assert (len(recordsets) == 0)
+
+
+def test_generate_dns_recordsets_returns_values_when_subdomain():
+    mail_from_provider = MailFromDomainProvider()
+    request = Request("Create", "example.com", "mail")
+    mail_from_provider.set_request(request, {})
+    assert(mail_from_provider.is_valid_request())
+    assert(mail_from_provider.domain == "example.com")
+    assert(mail_from_provider.mail_from_subdomain == "mail")
+
+    recordsets = mail_from_provider.generate_dns_recordsets()
+    assert (len(recordsets) == 2)
+    expected_mx = {
+        'Name': 'mail.example.com.',
+        'ResourceRecords': ['"10 feedback-smtp.eu-west-1.amazonses.com"'],
+        'TTL': '60',
+        'Type': 'MX'
+    }
+
+    expected_txt = {
+        'Name': 'mail.example.com.',
+        'ResourceRecords': ['v=spf1 include:amazonses.com ~all'],
+        'TTL': '60',
+        'Type': 'TXT'
+    }
+
+    assert(expected_mx in recordsets)
+    assert(expected_txt in recordsets)
+
+
+class Request(dict):
+    def __init__(
+        self, request_type, domain=None, mail_from_subdomain="", region="eu-west-1", physical_resource_id=None
+    ):
+        request_id = "request-%s" % uuid.uuid4()
+        self.update(
+            {
+                "RequestType": request_type,
+                "ResponseURL": "https://httpbin.org/put",
+                "StackId": "arn:aws:cloudformation:us-west-2:EXAMPLE/stack-name/guid",
+                "RequestId": request_id,
+                "ResourceType": "Custom::MailFromDomain",
+                "LogicalResourceId": "MyMailFromDomain",
+                "ResourceProperties": {"Domain": domain, "MailFromSubdomain": mail_from_subdomain},
+            }
+        )
+        if region:
+            self["ResourceProperties"]["Region"] = region
+
+        self["PhysicalResourceId"] = (
+            physical_resource_id
+            if physical_resource_id
+            else "initial-%s" % str(uuid.uuid4())
+        )


### PR DESCRIPTION
Initial draft of support for a custom MAIL FROM domain, including support for waiting for the MAIL FROM domain to become verified. It draws heavily on the pattern for `DomainIdentity` and `VerifiedIdentity`.

I have not attempted to write integration tests as the existing tests are configured for the Binx internal network, but I have put in some basic unit tests around confirming that the DNS verification records are correct. Sorry for the delay in getting this to you, hopefully there won't be too much effort at your end to add these and I hope this is useful.