### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,6 @@ You can verify the MAIL FROM domain in Route53 like this:
         Comment: !Sub 'SES MAIL FROM domain for ${ExternalDomainName}'
         HostedZoneId: !Ref 'HostedZone'
         RecordSets: !GetAtt 'MailFromDomain.RecordSets'
-	RecordSetDefaults:
-	  TTL: 60
-	  Weight: 1
-	  SetIdentifier: !Ref 'AWS::Region'
 ```
 
 To wait until the MAIL FROM domain is verified, add a [Custom::VerifiedMailFromDomain](docs/VerifiedMailFromDomain.md):

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ This will create a domain identity in the region, and return the DNS entry as at
         Comment: !Sub 'SES identity for ${ExternalDomainName}'
         HostedZoneId: !Ref 'HostedZone'
         RecordSets: !GetAtt 'DomainIdentity.RecordSets'
-	RecordSetDefaults:
-	  TTL: 60
-	  Weight: 1
-	  SetIdentifier: !Ref 'AWS::Region'
 ```
 
 To wait until the domain identity is verified, add a [Custom::VerifiedIdentity](docs/VerifiedIdentity.md):


### PR DESCRIPTION
RecordSetDefaults is not a property of AWS::Route53::RecordSetGroup

This should probably also be fixed in the blog post: https://binx.io/blog/2019/11/14/how-to-deploy-aws-ses-domain-identities-dkim-records-using-cloudformation/