### PR TITLE
Fixes for MailFromDomain resource

### DIFF
--- a/cloudformation/cfn-resource-provider.yaml
+++ b/cloudformation/cfn-resource-provider.yaml
@@ -48,6 +48,7 @@ Resources:
               - ses:SetIdentityNotificationTopic
               - ses:SetIdentityHeadersInNotificationsEnabled
               - ses:SetIdentityFeedbackForwardingEnabled
+              - ses:SetIdentityMailFromDomain
               - ses:ListIdentityPolicies
               - ses:GetIdentityPolicies
               - ses:PutIdentityPolicy

--- a/src/mail_from_domain_provider.py
+++ b/src/mail_from_domain_provider.py
@@ -72,7 +72,7 @@ class MailFromDomainProvider(SESProvider):
 
             ses.set_identity_mail_from_domain(
                 Identity=self.domain,
-                MailFromDomain=self.mail_from_subdomain,
+                MailFromDomain=f"{self.mail_from_subdomain}.{self.domain}",
                 BehaviorOnMXFailure=mx_failure_behaviour,
             )
 

--- a/src/mail_from_domain_provider.py
+++ b/src/mail_from_domain_provider.py
@@ -46,7 +46,7 @@ class MailFromDomainProvider(SESProvider):
                     "Type": "MX",
                     "Name": f"{self.mail_from_subdomain}.{self.domain}.",
                     "ResourceRecords": [
-                        f'"10 feedback-smtp.{self.region}.amazonses.com"'
+                        f'10 feedback-smtp.{self.region}.amazonses.com'
                     ],
                 }
             )
@@ -56,7 +56,7 @@ class MailFromDomainProvider(SESProvider):
                 {
                     "Type": "TXT",
                     "Name": f"{self.mail_from_subdomain}.{self.domain}.",
-                    "ResourceRecords": ["v=spf1 include:amazonses.com ~all"],
+                    "ResourceRecords": ['"v=spf1 include:amazonses.com ~all"'],
                 }
             )
             return [recordset_mx, recordset_txt]


### PR DESCRIPTION
There's a couple of bugs in the implementation of the MailFromDomain resource, specifically:

1) a bad parameter error occurs when making the API call as the Provided `MAIL-FROM` string is not a full (sub)domain but mearly the subdomain parameter passed directly to the `set_identity_mail_from_domain` api call [AWS expects the full domain](https://docs.aws.amazon.com/ses/latest/APIReference/API_SetIdentityMailFromDomain.html) even though it must be a subdomain of the identity.
2) The ResourceRecords returned from the `MailFromDomain` resource are not valid and cause errors when used in a `AWS::Route53::RecordSetGroup` resource.
3) permission error due to a missing `SetIdentityMailFromDomain` permission in the Lambda role which is needed to make the SES API call.